### PR TITLE
Fixes to align with cake-contrib guidelines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@
 [![NuGet](https://img.shields.io/nuget/v/Cake.Codecov.svg)](https://www.nuget.org/packages/Cake.Codecov/)
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg?maxAge=2592000)](https://gitter.im/cake-contrib/Lobby)
 
-A Cake addin for Codecov. In order to use this addin, add to the top of your Cake script
+A [Cake](http://cakebuild.net/) addin for [Codecov](https://codecov.io/).
+
+## Usage
+
+ In order to use this addin, add to your Cake script
 
 ```csharp
 #tool nuget:?package=Codecov
 #addin nuget:?package=Cake.Codecov
 ```
 
-## Examples
+Then use one of the following snippets to upload your coverage report to Codecov
 
 ```csharp
 Task("Upload-Coverage")
@@ -64,10 +68,10 @@ Task("Upload-Coverage")
 
 ## Codecov Tips
 
-1. The [Codecov](https://github.com/codecov/codecov-exe) uploader defined in `#tool nuget:?package=Codecov` currently only supports windows builds. However, OS X and Linux builds should come soon. In the mean time, there is a [bash](https://github.com/codecov/codecov-bash) uploader that can be used.
+1. The [codecov-exe](https://github.com/codecov/codecov-exe) uploader defined in `#tool nuget:?package=Codecov` currently only supports windows builds. However, OS X and Linux builds should come soon. In the mean time, there is a [bash global uploader](https://github.com/codecov/codecov-bash) that can be used.
 2. Many CI services (like AppVeyor) do not require you to provide a Codecov upload token. However, TeamCity is a rare exception.
-3. Using Codecov with TeamCity MAY require configuration. Please refer to the [documentation](https://github.com/codecov/codecov-exe#teamcity).
+3. Using Codecov with TeamCity MAY require configuration. Please refer to the [codecov-exe documentation](https://github.com/codecov/codecov-exe#teamcity).
 
 # Questions
 
-Feel free to open an issue or **@larzw** me via [Gitter](https://gitter.im/cake-contrib/Lobby)
+Feel free to open an [issue](https://github.com/cake-contrib/Cake.Codecov/issues) or **@larzw** me via [Gitter](https://gitter.im/cake-contrib/Lobby).

--- a/Source/Cake.Codecov/Cake.Codecov.csproj
+++ b/Source/Cake.Codecov/Cake.Codecov.csproj
@@ -15,13 +15,26 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>.\Cake.Codecov.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.6|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard1.6\Cake.Codecov.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.6|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard1.6\Cake.Codecov.xml</DocumentationFile>
   </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+    <DocumentationFile>bin\Debug\net45\Cake.Codecov.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
+    <DocumentationFile>bin\Release\net45\Cake.Codecov.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.19.1" />
+    <AdditionalFiles Include="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Cake.Core" Version="0.17.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Source/Cake.Codecov/Cake.Codecov.ruleset
+++ b/Source/Cake.Codecov/Cake.Codecov.ruleset
@@ -1,0 +1,118 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for StyleCop.Analyzers" Description="Code analysis rules for StyleCop.Analyzers.csproj." ToolsVersion="15.0">
+  <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
+    <Rule Id="AvoidAsyncSuffix" Action="Error" />
+    <Rule Id="AvoidAsyncVoid" Action="Error" />
+    <Rule Id="UseAsyncSuffix" Action="Error" />
+    <Rule Id="UseConfigureAwait" Action="Error" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1001" Action="Warning" />
+    <Rule Id="CA1009" Action="Warning" />
+    <Rule Id="CA1016" Action="Warning" />
+    <Rule Id="CA1033" Action="Warning" />
+    <Rule Id="CA1049" Action="Warning" />
+    <Rule Id="CA1060" Action="Warning" />
+    <Rule Id="CA1061" Action="Warning" />
+    <Rule Id="CA1063" Action="Warning" />
+    <Rule Id="CA1065" Action="Warning" />
+    <Rule Id="CA1301" Action="Warning" />
+    <Rule Id="CA1400" Action="Warning" />
+    <Rule Id="CA1401" Action="Warning" />
+    <Rule Id="CA1403" Action="Warning" />
+    <Rule Id="CA1404" Action="Warning" />
+    <Rule Id="CA1405" Action="Warning" />
+    <Rule Id="CA1410" Action="Warning" />
+    <Rule Id="CA1415" Action="Warning" />
+    <Rule Id="CA1821" Action="Warning" />
+    <Rule Id="CA1900" Action="Warning" />
+    <Rule Id="CA1901" Action="Warning" />
+    <Rule Id="CA2002" Action="Warning" />
+    <Rule Id="CA2100" Action="Warning" />
+    <Rule Id="CA2101" Action="Warning" />
+    <Rule Id="CA2108" Action="Warning" />
+    <Rule Id="CA2111" Action="Warning" />
+    <Rule Id="CA2112" Action="Warning" />
+    <Rule Id="CA2114" Action="Warning" />
+    <Rule Id="CA2116" Action="Warning" />
+    <Rule Id="CA2117" Action="Warning" />
+    <Rule Id="CA2122" Action="Warning" />
+    <Rule Id="CA2123" Action="Warning" />
+    <Rule Id="CA2124" Action="Warning" />
+    <Rule Id="CA2126" Action="Warning" />
+    <Rule Id="CA2131" Action="Warning" />
+    <Rule Id="CA2132" Action="Warning" />
+    <Rule Id="CA2133" Action="Warning" />
+    <Rule Id="CA2134" Action="Warning" />
+    <Rule Id="CA2137" Action="Warning" />
+    <Rule Id="CA2138" Action="Warning" />
+    <Rule Id="CA2140" Action="Warning" />
+    <Rule Id="CA2141" Action="Warning" />
+    <Rule Id="CA2146" Action="Warning" />
+    <Rule Id="CA2147" Action="Warning" />
+    <Rule Id="CA2149" Action="Warning" />
+    <Rule Id="CA2200" Action="Warning" />
+    <Rule Id="CA2202" Action="Warning" />
+    <Rule Id="CA2207" Action="Warning" />
+    <Rule Id="CA2212" Action="Warning" />
+    <Rule Id="CA2213" Action="Warning" />
+    <Rule Id="CA2214" Action="Warning" />
+    <Rule Id="CA2216" Action="Warning" />
+    <Rule Id="CA2220" Action="Warning" />
+    <Rule Id="CA2229" Action="Warning" />
+    <Rule Id="CA2231" Action="Warning" />
+    <Rule Id="CA2232" Action="Warning" />
+    <Rule Id="CA2235" Action="Warning" />
+    <Rule Id="CA2236" Action="Warning" />
+    <Rule Id="CA2237" Action="Warning" />
+    <Rule Id="CA2238" Action="Warning" />
+    <Rule Id="CA2240" Action="Warning" />
+    <Rule Id="CA2241" Action="Warning" />
+    <Rule Id="CA2242" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0003" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1000" Action="Error" />
+    <Rule Id="SA1001" Action="Error" />
+    <Rule Id="SA1021" Action="Error" />
+    <Rule Id="SA1022" Action="Error" />
+    <Rule Id="SA1100" Action="Error" />
+    <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1106" Action="Error" />
+    <Rule Id="SA1111" Action="Error" />
+    <Rule Id="SA1112" Action="Error" />
+    <Rule Id="SA1119" Action="Error" />
+    <Rule Id="SA1121" Action="Error" />
+    <Rule Id="SA1122" Action="Error" />
+    <Rule Id="SA1133" Action="Error" />
+    <Rule Id="SA1300" Action="Error" />
+    <Rule Id="SA1302" Action="Error" />
+    <Rule Id="SA1303" Action="Error" />
+    <Rule Id="SA1304" Action="Error" />
+    <Rule Id="SA1305" Action="Warning" />
+    <Rule Id="SA1309" Action="None" />
+    <Rule Id="SA1311" Action="Error" />
+    <Rule Id="SA1400" Action="Error" />
+    <Rule Id="SA1401" Action="Error" />
+    <Rule Id="SA1402" Action="Error" />
+    <Rule Id="SA1403" Action="Error" />
+    <Rule Id="SA1404" Action="Error" />
+    <Rule Id="SA1405" Action="Error" />
+    <Rule Id="SA1406" Action="Error" />
+    <Rule Id="SA1407" Action="Error" />
+    <Rule Id="SA1408" Action="Error" />
+    <Rule Id="SA1410" Action="Error" />
+    <Rule Id="SA1411" Action="Error" />
+    <Rule Id="SA1412" Action="None" />
+    <Rule Id="SA1413" Action="None" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1603" Action="Error" />
+    <Rule Id="SA1609" Action="Warning" />
+    <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1636" Action="Error" />
+    <Rule Id="SA1642" Action="Error" />
+    <Rule Id="SA1643" Action="Error" />
+  </Rules>
+</RuleSet>

--- a/Source/Cake.Codecov/CodecovAliases.cs
+++ b/Source/Cake.Codecov/CodecovAliases.cs
@@ -6,10 +6,13 @@ namespace Cake.Codecov
 {
     /// <summary>
     /// <para>
-    /// Uploads coverage reports to <see href="https://codecov.io">Codecov</see>. Note that, many CI services (like AppVeyor) do not require you to provide a Codecov upload token. However, TeamCity is a rare exception.
+    /// Uploads coverage reports to <see href="https://codecov.io">Codecov</see>. Note that, many CI
+    /// services (like AppVeyor) do not require you to provide a Codecov upload token. However,
+    /// TeamCity is a rare exception.
     /// </para>
     /// <para>
-    /// In order to use the commands for this addin, you will need to include the following in your cake script:
+    /// In order to use the commands for this addin, you will need to include the following in your
+    /// cake script:
     /// <code>
     /// #tool nuget:?package=Codecov
     /// </code>
@@ -34,7 +37,8 @@ namespace Cake.Codecov
         }
 
         /// <summary>
-        /// Uploads coverage reports to <see href="https://codecov.io">Codecov</see> by specifying the report files and Codecov token.
+        /// Uploads coverage reports to <see href="https://codecov.io">Codecov</see> by specifying
+        /// the report files and Codecov token.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="files">The coverage reports.</param>
@@ -46,7 +50,9 @@ namespace Cake.Codecov
         }
 
         /// <summary>
-        /// Uploads coverage reports to <see href="https://codecov.io">Codecov</see> by specifying the report files. Note that, many CI services (like AppVeyor) do not require you to provide a Codecov upload token. However, TeamCity is a rare exception.
+        /// Uploads coverage reports to <see href="https://codecov.io">Codecov</see> by specifying
+        /// the report files. Note that, many CI services (like AppVeyor) do not require you to
+        /// provide a Codecov upload token. However, TeamCity is a rare exception.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="files">The coverage reports.</param>
@@ -57,7 +63,8 @@ namespace Cake.Codecov
         }
 
         /// <summary>
-        /// Uploads coverage report to <see href="https://codecov.io">Codecov</see> by specifying the report file and Codecov token.
+        /// Uploads coverage report to <see href="https://codecov.io">Codecov</see> by specifying the
+        /// report file and Codecov token.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="file">The coverage report.</param>
@@ -69,7 +76,9 @@ namespace Cake.Codecov
         }
 
         /// <summary>
-        /// Uploads coverage report to <see href="https://codecov.io">Codecov</see> by specifying the report file. Note that, many CI services (like AppVeyor) do not require you to provide a Codecov upload token. However, TeamCity is a rare exception.
+        /// Uploads coverage report to <see href="https://codecov.io">Codecov</see> by specifying the
+        /// report file. Note that, many CI services (like AppVeyor) do not require you to provide a
+        /// Codecov upload token. However, TeamCity is a rare exception.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="file">The coverage report.</param>

--- a/Source/Cake.Codecov/CodecovRunner.cs
+++ b/Source/Cake.Codecov/CodecovRunner.cs
@@ -9,15 +9,9 @@ namespace Cake.Codecov
 {
     internal sealed class CodecovRunner : Tool<CodecovSettings>
     {
-        internal CodecovRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools) : base(fileSystem, environment, processRunner, tools)
+        internal CodecovRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IToolLocator tools)
+            : base(fileSystem, environment, processRunner, tools)
         {
-        }
-
-        protected override string GetToolName() => "Codecov";
-
-        protected override IEnumerable<string> GetToolExecutableNames()
-        {
-            yield return "codecov.exe";
         }
 
         internal void Run(CodecovSettings settings)
@@ -28,6 +22,13 @@ namespace Cake.Codecov
             }
 
             Run(settings, GetArguments(settings));
+        }
+
+        protected override string GetToolName() => "Codecov";
+
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            yield return "codecov.exe";
         }
 
         private static ProcessArgumentBuilder GetArguments(CodecovSettings settings)

--- a/Source/Cake.Codecov/CodecovSettings.cs
+++ b/Source/Cake.Codecov/CodecovSettings.cs
@@ -4,46 +4,68 @@ using Cake.Core.Tooling;
 namespace Cake.Codecov
 {
     /// <summary>
-    /// Contains settings used by <see cref="CodecovRunner"/>. See <see href="https://github.com/codecov/codecov-exe/blob/master/Source/Codecov/Program/CommandLineOptions.cs">CommandLineOptions</see> or run <code>.\codecov.exe --help</code> for more details.
+    /// Contains settings used by <see cref="CodecovRunner"/>. See <see
+    /// href="https://github.com/codecov/codecov-exe/blob/master/Source/Codecov/Program/CommandLineOptions.cs">CommandLineOptions</see>
+    /// or run
+    /// <code>
+    /// .\codecov.exe --help
+    /// </code>
+    /// for more details.
     /// </summary>
     public sealed class CodecovSettings : ToolSettings
     {
         /// <summary>
         /// Gets or sets a property specifing the branch name.
         /// </summary>
+        /// <value>A property specifing the branch name.</value>
         public string Branch { get; set; }
 
         /// <summary>
         /// Gets or sets a property specifing the build number.
         /// </summary>
+        /// <value>A property specifing the build number.</value>
         public string Build { get; set; }
 
         /// <summary>
         /// Gets or sets a property specifing the commit sha.
         /// </summary>
+        /// <value>A property specifing the commit sha.</value>
         public string Commit { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to toggle functionalities. (1) --disable-network.
         /// Disable uploading the file network.
         /// </summary>
+        /// <value>
+        /// A value indicating whether to toggle functionalities. (1) --disable-network. Disable
+        /// uploading the file network.
+        /// </value>
         public bool DisableNetwork { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to don't upload and dump to stdin.
         /// </summary>
+        /// <value>A value indicating whether to don't upload and dump to stdin.</value>
         public bool Dump { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifing the enviornment variables to be included with this build.
         /// (1) CODECOV_ENV=VAR1,VAR2. (2) -e VAR1 VAR2.
         /// </summary>
+        /// <value>
+        /// A value specifing the enviornment variables to be included with this build. (1)
+        /// CODECOV_ENV=VAR1,VAR2. (2) -e VAR1 VAR2.
+        /// </value>
         public IEnumerable<string> Envs { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifing the target file(s) to upload. (1) -f 'path/to/file'. Only
         /// upload this file. (2) -f 'path/to/file1 path/to/file2'. Only upload these files.
         /// </summary>
+        /// <value>
+        /// A value specifing the target file(s) to upload. (1) -f 'path/to/file'. Only upload this
+        /// file. (2) -f 'path/to/file1 path/to/file2'. Only upload these files.
+        /// </value>
         public IEnumerable<string> Files { get; set; }
 
         /// <summary>
@@ -51,60 +73,88 @@ namespace Cake.Codecov
         /// unittests. This upload is only unittests. (2) --flag integration. This upload is only
         /// integration tests. (3) --flag ut,chrome. This upload is chrome - UI tests.
         /// </summary>
+        /// <value>
+        /// A value specifing the flag the upload to group coverage metrics. (1) --flag unittests.
+        /// This upload is only unittests. (2) --flag integration. This upload is only integration
+        /// tests. (3) --flag ut,chrome. This upload is chrome - UI tests.
+        /// </value>
         public string Flags { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifing the custom defined name of the upload. Visible in Codecov UI.
         /// </summary>
+        /// <value>
+        /// A value specifing the custom defined name of the upload. Visible in Codecov UI.
+        /// </value>
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to remove color from the output.
         /// </summary>
+        /// <value>A value indicating whether to remove color from the output.</value>
         public bool NoColor { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifing the pull request number.
         /// </summary>
+        /// <value>A value specifing the pull request number.</value>
         public string Pr { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to exit with 1 if not successful. Default will
         /// Exit with 0.
         /// </summary>
+        /// <value>
+        /// A value indicating whether to exit with 1 if not successful. Default will Exit with 0.
+        /// </value>
         public bool Required { get; set; }
 
         /// <summary>
         /// Gets or sets a value used when not in git project to identify project root directory.
         /// </summary>
+        /// <value>A value used when not in git project to identify project root directory.</value>
         public string Root { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifing the owner/repo slug used instead of the private repo token
         /// in Enterprise. (option) Set environment variable CODECOV_SLUG=:owner/:repo.
         /// </summary>
+        /// <value>
+        /// A value specifing the owner/repo slug used instead of the private repo token in
+        /// Enterprise. (option) Set environment variable CODECOV_SLUG=:owner/:repo.
+        /// </value>
         public string Slug { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifing the git tag.
         /// </summary>
+        /// <value>A value specifing the git tag.</value>
         public string Tag { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifing the private repository token. (option) set the enviornment
         /// variable CODECOV_TOKEN-uuid. (1) -t @/path/to/token_file. (2) -t uuid.
         /// </summary>
+        /// <value>
+        /// A value specifing the private repository token. (option) set the enviornment variable
+        /// CODECOV_TOKEN-uuid. (1) -t @/path/to/token_file. (2) -t uuid.
+        /// </value>
         public string Token { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifing the target url for Enterprise customers. (option) Set
         /// environment variable CODECOV_URL=https://my-hosted-codecov.com.
         /// </summary>
+        /// <value>
+        /// A value specifing the target url for Enterprise customers. (option) Set environment
+        /// variable CODECOV_URL=https://my-hosted-codecov.com.
+        /// </value>
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to run in verbose mode.
         /// </summary>
+        /// <value>A value indicating whether to run in verbose mode.</value>
         public bool Verbose { get; set; }
     }
 }

--- a/Source/Cake.Codecov/stylecop.json
+++ b/Source/Cake.Codecov/stylecop.json
@@ -1,0 +1,8 @@
+﻿{
+    "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+    "settings": {
+        "orderingRules": {
+            "usingDirectivesPlacement": "outsideNamespace"
+        }
+    }
+}


### PR DESCRIPTION
* Updated readme.
* Built againsts lower cake version, 0.17.0
* Added StyleCopAnalyzers. Currently there is an issue when building net standard apps on the commandline. The build will produce a large number of warnings.
* Fixed xml documents.