### PR TITLE
Implemented dogfooding for coverage reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "Users/appveyor/AppData/Local/Temp/1/::"

--- a/setup.cake
+++ b/setup.cake
@@ -1,7 +1,6 @@
 #tool "nuget:?package=GitVersion.CommandLine"
 #tool nuget:?package=OpenCover
 #tool nuget:?package=Codecov
-#addin nuget:?package=Cake.Codecov
 #addin nuget:?package=Cake.Figlet
 
 var target = Argument("target", "Default");
@@ -32,12 +31,22 @@ Task("Tests").IsDependentOn("Build").Does(() =>
 	OpenCover(tool => tool.DotNetCoreTest("./Source/Cake.Codecov.Tests/Cake.Codecov.Tests.csproj"), new FilePath("./Source/Cake.Codecov/bin/coverage.xml"), new OpenCoverSettings { OldStyle = true }.WithFilter("+[Cake.Codecov]*"));
 });
 
-Task("Coverage").IsDependentOn("Tests").Does(() =>
+Task("Coverage").IsDependentOn("Tests").WithCriteria(AppVeyor.IsRunningOnAppVeyor).Does(() =>
 {
-	if(AppVeyor.IsRunningOnAppVeyor)
-	{
-		Codecov("./Source/Cake.Codecov/bin/coverage.xml");
-	}
+	// Using GetFiles instead of File just so we don't need to make a call to MakeAbsolute.
+	var file = GetFiles("./Source/**/net45/Cake.Codecov.dll").First();
+    var tool = Context.Tools.Resolve("Codecov.exe");
+    var reportFile = GetFiles("./Source/**/coverage.xml").First();
+	Information("Loading built addin from: {0}", file);
+    Information("Using Codecov tool from: {0}", tool);
+    Information("Using Coverage report from: {0}", reportFile);
+		CakeExecuteExpression(
+			string.Format(
+				@"#reference ""{0}""
+Codecov(new CodecovSettings {{ ToolPath = ""{1}"", Files = new[] {{ ""{2}"" }}, Root = ""{3}"" }});
+				",
+				file, tool, reportFile, Directory("./").Path.MakeAbsolute(Context.Environment))
+		);
 });
 
 Task("Pack").IsDependentOn("Coverage").Does(() =>

--- a/setup.cake
+++ b/setup.cake
@@ -8,7 +8,7 @@ var configuration = Argument("configuration", "Release");
 
 Setup(context =>
 {
-    Information(Figlet("Cake.Codecov"));
+	Information(Figlet("Cake.Codecov"));
 });
 
 Task("Clean").Does(() =>
@@ -35,11 +35,11 @@ Task("Coverage").IsDependentOn("Tests").WithCriteria(AppVeyor.IsRunningOnAppVeyo
 {
 	// Using GetFiles instead of File just so we don't need to make a call to MakeAbsolute.
 	var file = GetFiles("./Source/**/net45/Cake.Codecov.dll").First();
-    var tool = Context.Tools.Resolve("Codecov.exe");
-    var reportFile = GetFiles("./Source/**/coverage.xml").First();
+	var tool = Context.Tools.Resolve("Codecov.exe");
+	var reportFile = GetFiles("./Source/**/coverage.xml").First();
 	Information("Loading built addin from: {0}", file);
-    Information("Using Codecov tool from: {0}", tool);
-    Information("Using Coverage report from: {0}", reportFile);
+	Information("Using Codecov tool from: {0}", tool);
+	Information("Using Coverage report from: {0}", reportFile);
 		CakeExecuteExpression(
 			string.Format(
 				@"#reference ""{0}""


### PR DESCRIPTION
This PR changes how we upload the coverage report, by using the recently built coverage tool instead of downloading the previous version.

(Opened as a PR to see if you agree with the changes before merging it to master).

implements #2 