### PR TITLE
(#218,#285,#288) Update Cake.Core to v2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           # codecov in cake.recipe needs 2.1!
           # version used for GitReleaseManager needs .NET Core 3.0
           dotnet-version: |
-            2.1.x
+            3.1.x
             5.0.x
             6.0.x
       - name: Build Addin

--- a/.github/workflows/pre-release-notes.yml
+++ b/.github/workflows/pre-release-notes.yml
@@ -25,7 +25,7 @@ jobs:
           # codecov in cake.recipe needs 2.1!
           # version used for GitReleaseManager needs .NET Core 3.0
           dotnet-version: |
-            2.1.x
+            3.1.x
             5.0.x
             6.0.x
       - name: Set up git version

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -25,7 +25,7 @@ jobs:
           # codecov in cake.recipe needs 2.1!
           # version used for GitReleaseManager needs .NET Core 3.0
           dotnet-version: |
-            2.1.x
+            3.1.x
             5.0.x
             6.0.x
       - name: Set up git version

--- a/Source/Cake.Codecov.Tests/Cake.Codecov.Tests.csproj
+++ b/Source/Cake.Codecov.Tests/Cake.Codecov.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Source/Cake.Codecov.Tests/Cake.Codecov.Tests.csproj
+++ b/Source/Cake.Codecov.Tests/Cake.Codecov.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks Condition="'$(OS)' != 'Unix'">net5.0;netcoreapp2.1;net461</TargetFrameworks>
-        <TargetFrameworks Condition="'$(OS)' == 'Unix'">net5.0;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netcoreapp2.1</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Source/Cake.Codecov.Tests/Cake.Codecov.Tests.csproj
+++ b/Source/Cake.Codecov.Tests/Cake.Codecov.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="AppVeyor.TestLogger" Version="2.0.0" />
-        <PackageReference Include="Cake.Testing" Version="1.1.0" />
+        <PackageReference Include="Cake.Testing" Version="2.3.0" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Source/Cake.Codecov.Tests/CodecovRunnerFixture.cs
+++ b/Source/Cake.Codecov.Tests/CodecovRunnerFixture.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Cake.Codecov.Internals;
 using Cake.Testing.Fixtures;
 
@@ -8,7 +9,7 @@ namespace Cake.Codecov.Tests
         private readonly IPlatformDetector _platformDetector;
 
         public CodecovRunnerFixture()
-            : base("codecov.exe")
+            : base(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "codecov.exe" : "codecov")
         {
         }
 
@@ -20,9 +21,9 @@ namespace Cake.Codecov.Tests
 
         protected override void RunTool()
         {
-            var tool = _platformDetector != null ?
-                new CodecovRunner(_platformDetector, FileSystem, Environment, ProcessRunner, Tools) :
-                new CodecovRunner(FileSystem, Environment, ProcessRunner, Tools);
+            var tool = _platformDetector != null
+                ? new CodecovRunner(_platformDetector, FileSystem, Environment, ProcessRunner, Tools)
+                : new CodecovRunner(FileSystem, Environment, ProcessRunner, Tools);
             tool.Run(Settings);
         }
     }

--- a/Source/Cake.Codecov/Cake.Codecov.csproj
+++ b/Source/Cake.Codecov/Cake.Codecov.csproj
@@ -35,7 +35,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
+        <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
         <PackageReference Include="CakeContrib.Guidelines" Version="1.4.0" PrivateAssets="All" />
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">

--- a/Source/Cake.Codecov/Cake.Codecov.csproj
+++ b/Source/Cake.Codecov/Cake.Codecov.csproj
@@ -8,7 +8,7 @@
         <Description>Cake addin that extends Cake with the ability to use the official Codecov CLI.</Description>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Codecov.xml</DocumentationFile>
         <NeutralLanguage>en-GB</NeutralLanguage>
-        <TargetFrameworks>net5.0;netstandard2.0;net461</TargetFrameworks>
+        <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
     <!-- Package information -->

--- a/Source/Cake.Codecov/Cake.Codecov.csproj
+++ b/Source/Cake.Codecov/Cake.Codecov.csproj
@@ -8,7 +8,7 @@
         <Description>Cake addin that extends Cake with the ability to use the official Codecov CLI.</Description>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Codecov.xml</DocumentationFile>
         <NeutralLanguage>en-GB</NeutralLanguage>
-        <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
     <!-- Package information -->
@@ -27,7 +27,7 @@
     </PropertyGroup>
     <ItemGroup>
         <AdditionalFiles Include="stylecop.json" />
-        <None Include="../../README.md" Pack="true" PackagePath="docs/"/>
+        <None Include="../../README.md" Pack="true" PackagePath="docs/" />
     </ItemGroup>
     <!-- Package References -->
     <ItemGroup>

--- a/Source/Cake.Codecov/CodecovRunner.cs
+++ b/Source/Cake.Codecov/CodecovRunner.cs
@@ -55,10 +55,11 @@ namespace Cake.Codecov
             }
             else
             {
-                // Just to make sonarlint happy :)
+                // The official version of Codecov CLI can not run with the exe
+                // on anything other than Windows. As such we only return this
+                // in the else statement.
+                yield return "codecov.exe";
             }
-
-            yield return "codecov.exe";
         }
 
         protected override string GetToolName() => "Codecov";

--- a/setup.cake
+++ b/setup.cake
@@ -38,7 +38,8 @@ ToolSettings.SetToolPreprocessorDirectives(
 BuildParameters.Tasks.UploadCodecovReportTask
     .IsDependentOn("DotNetCore-Pack")
     .Does<BuildVersion>((version) => RequireTool(ToolSettings.CodecovTool, () => {
-        var nugetPkg = $"nuget:file://{MakeAbsolute(BuildParameters.Paths.Directories.NuGetPackages)}?package=Cake.Codecov&version={version.SemVersion}&prerelease";
+        // var nugetPkg =  $"nuget:file://{MakeAbsolute(BuildParameters.Paths.Directories.NuGetPackages)}?package=Cake.Codecov&version={version.SemVersion}&prerelease";
+        var nugetPkg = "nuget:?package=Cake.Codecov&version=1.1.0"; // We are unable to dogfood the library until Cake.Recipe supports Cake 2.0.0
         Information("PATH: " + nugetPkg);
 
         var coverageFilter = BuildParameters.Paths.Directories.TestCoverage + "/coverlet/*.xml";


### PR DESCRIPTION
This updates Cake.Core and related libraries to version 2.0.0, as well as removing support for .NET Framework 4.6.1 and adding support for .NET 6.0 and .NET Core 3.1

- fixes #218
- fixes #285
- fixes #288