### PR TITLE
(#308) Remove deprecated properties

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -210,3 +210,6 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# SA1516: Elements should be separated by blank line
+dotnet_diagnostic.SA1516.severity = none

--- a/Source/Cake.Codecov.Tests/CodecovRunnerTests.cs
+++ b/Source/Cake.Codecov.Tests/CodecovRunnerTests.cs
@@ -258,32 +258,6 @@ namespace Cake.Codecov.Tests
             result.Args.Should().Be(@"--sha ""603e02d40093d0649cfa787d846ae4ccc038085c""");
         }
 
-        [Fact, Obsolete("Remove test in v2.0.0")]
-        public void Should_Enable_DryRun_When_DisableNetwork_Is_Set()
-        {
-            // Given
-            var fixture = new CodecovRunnerFixture { Settings = { DisableNetwork = true } };
-
-            // When
-            var result = fixture.Run();
-
-            // Then
-            result.Args.Should().Be("--dryRun");
-        }
-
-        [Fact, Obsolete("Remove test in v2.0.0")]
-        public void Should_Enable_DryRun_When_Dump_Is_Set()
-        {
-            // Given
-            var fixture = new CodecovRunnerFixture { Settings = { Dump = true } };
-
-            // When
-            var result = fixture.Run();
-
-            // Then
-            result.Args.Should().Be("--dryRun");
-        }
-
         [Fact]
         public void Should_Enable_DryRun()
         {
@@ -388,19 +362,6 @@ namespace Cake.Codecov.Tests
             result.Args.Should().Be(@"--name ""custom name""");
         }
 
-        [Fact, Obsolete("Remove test in v2.0.0")]
-        public void Should_Ignore_NoColor()
-        {
-            // Given
-            var fixture = new CodecovRunnerFixture { Settings = { NoColor = true } };
-
-            // When
-            var result = fixture.Run();
-
-            // Then
-            result.Args.Should().BeNullOrEmpty();
-        }
-
         [Fact]
         public void Should_Set_Pr()
         {
@@ -412,19 +373,6 @@ namespace Cake.Codecov.Tests
 
             // Then
             result.Args.Should().Be(@"--pr ""1""");
-        }
-
-        [Fact, Obsolete("Remove in v2.0.0")]
-        public void Should_Enable_NonZero_When_Required_Is_Set()
-        {
-            // Given
-            var fixture = new CodecovRunnerFixture { Settings = { Required = true } };
-
-            // When
-            var result = fixture.Run();
-
-            // Then
-            result.Args.Should().Be("--nonZero");
         }
 
         [Fact]
@@ -451,19 +399,6 @@ namespace Cake.Codecov.Tests
 
             // Then
             result.Args.Should().Be(@"--parent ""some-kind-of-sha""");
-        }
-
-        [Fact, Obsolete("Remove test in v2.0.0")]
-        public void Should_Set_RootDirectory_When_Root_Is_Set()
-        {
-            // Given
-            var fixture = new CodecovRunnerFixture { Settings = { Root = @".\working" } };
-
-            // When
-            var result = fixture.Run();
-
-            // Then
-            result.Args.Should().Be(@"--rootDir ""working""");
         }
 
         [Fact]

--- a/Source/Cake.Codecov.Tests/CodecovSettingsTests.cs
+++ b/Source/Cake.Codecov.Tests/CodecovSettingsTests.cs
@@ -85,34 +85,6 @@ namespace Cake.Codecov.Tests
             settings.CleanReports.Should().BeTrue();
         }
 
-        [Fact, Obsolete("Remove test in v2.0.0")]
-        public void Should_Set_DisableNetwork_Value()
-        {
-            // Given
-            var settings = new CodecovSettings
-            {
-                // When
-                DisableNetwork = true
-            };
-
-            // Then
-            settings.DisableNetwork.Should().BeTrue();
-        }
-
-        [Fact, Obsolete("Remove test in v2.0.0")]
-        public void Should_Set_Dump_Value()
-        {
-            // Given
-            var settings = new CodecovSettings
-            {
-                // When
-                Dump = true
-            };
-
-            // Then
-            settings.Dump.Should().BeTrue();
-        }
-
         [Fact]
         public void Should_Set_EnableGcovSupport_Value()
         {
@@ -202,20 +174,6 @@ namespace Cake.Codecov.Tests
             settings.Name.Should().Be(expected);
         }
 
-        [Fact, Obsolete("Remove test in v2.0.0")]
-        public void Should_Not_Set_NoColor_Value()
-        {
-            // Given
-            var settings = new CodecovSettings
-            {
-                // When
-                NoColor = true
-            };
-
-            // Then
-            settings.NoColor.Should().BeFalse();
-        }
-
         [Fact]
         public void Should_Set_ParentSha_Value()
         {
@@ -244,35 +202,6 @@ namespace Cake.Codecov.Tests
 
             // Then
             settings.Pr.Should().Be(expected);
-        }
-
-        [Fact, Obsolete("Remove test in v2.0.0")]
-        public void Should_Set_Required_Value()
-        {
-            // Given
-            var settings = new CodecovSettings
-            {
-                // When
-                Required = true
-            };
-
-            // Then
-            settings.Required.Should().BeTrue();
-        }
-
-        [Fact, Obsolete("Remove test in v2.0.0")]
-        public void Should_Set_Root_Value()
-        {
-            // Given
-            var expected = (DirectoryPath)"C:/test/root";
-            var settings = new CodecovSettings
-            {
-                // When
-                Root = expected
-            };
-
-            // Then
-            settings.Root.Should().BeEquivalentTo(expected);
         }
 
         [Fact]

--- a/Source/Cake.Codecov/CodecovSettings.cs
+++ b/Source/Cake.Codecov/CodecovSettings.cs
@@ -62,35 +62,6 @@ namespace Cake.Codecov
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to toggle functionalities. (1)
-        /// --disable-network. Disable uploading the file network.
-        /// </summary>
-        /// <value>
-        /// A value indicating whether to toggle functionalities. (1) --disable-network. Disable
-        /// uploading the file network.
-        /// </value>
-        /// <remarks>
-        /// This function has been made a no-op, and do not have any functionality.
-        /// </remarks>
-        [Obsolete("This property have been deprecated, and will be removed in v2.0.0. Use property 'DryRun' instead.")]
-        public bool DisableNetwork
-        {
-            get => DryRun;
-            set => DryRun = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to don't upload and dump to stdin.
-        /// </summary>
-        /// <value>A value indicating whether to don't upload and dump to stdin.</value>
-        [Obsolete("This property have been deprecated, and will be removed in v2.0.0. Use property 'DryRun' instead.")]
-        public bool Dump
-        {
-            get => DryRun;
-            set => DryRun = value;
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether files should be uploaded to Codecov.
         /// </summary>
         /// <value>A value indicating whether files should be uploaded to Codecov.</value>
@@ -178,17 +149,6 @@ namespace Cake.Codecov
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to remove color from the output.
-        /// </summary>
-        /// <value>A value indicating whether to remove color from the output.</value>
-        [Obsolete("This property have been deprecated, and will be removed in v2.0.0.")]
-        public bool NoColor
-        {
-            get => false;
-            set { }
-        }
-
-        /// <summary>
         /// Gets or sets a value indicating whether Codecov should exit with a non-zero exit code on errors.
         /// </summary>
         /// <value>Whether Codecov should exit with a non-zero exit code on errors.</value>
@@ -219,31 +179,6 @@ namespace Cake.Codecov
         {
             get => GetValue<string>("--pr");
             set => SetValue("--pr", value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to exit with 1 if not successful. Default will
-        /// Exit with 0.
-        /// </summary>
-        /// <value>
-        /// A value indicating whether to exit with 1 if not successful. Default will Exit with 0.
-        /// </value>
-        [Obsolete("This property have been deprecated, and will be removed in v2.0.0. Use property 'NonZero' instead.")]
-        public bool Required
-        {
-            get => NonZero;
-            set => NonZero = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value used when not in git project to identify project root directory.
-        /// </summary>
-        /// <value>A value used when not in git project to identify project root directory.</value>
-        [Obsolete("This property have been deprecated, and will be removed in v2.0.0. Use property 'RootDirectory' instead.")]
-        public DirectoryPath Root
-        {
-            get => RootDirectory;
-            set => RootDirectory = value;
         }
 
         /// <summary>

--- a/setup.cake
+++ b/setup.cake
@@ -64,8 +64,7 @@ BuildParameters.Tasks.UploadCodecovReportTask
 Codecov(new CodecovSettings {{
     Files = new[] {{ ""{1}"" }},
     RootDirectory = ""{2}"",
-    NonZero = true,
-    DryRun  = string.IsNullOrEmpty(EnvironmentVariable(""CODECOV_TOKEN""))
+    NonZero = !string.IsNullOrEmpty(EnvironmentVariable(""CODECOV_TOKEN""))
 }});",
             nugetPkg, coverageFilter, BuildParameters.RootDirectoryPath);
 


### PR DESCRIPTION
In version 1.1.0 we deprecated several properties that does not match properties that is supported in the official Chocolatey CLI.

Now that we are moving to the next major version, this PR removes these properties.

fixes #308