### PR TITLE
(#332) Normalize file paths for --file argument in CodecovRunner

### DIFF
--- a/Source/Cake.Codecov.Tests/CodecovAliasesTests.cs
+++ b/Source/Cake.Codecov.Tests/CodecovAliasesTests.cs
@@ -52,7 +52,7 @@ namespace Cake.Codecov.Tests
 
             var result = fixture.Run();
 
-            result.Args.Should().Contain($"--file \"{string.Join("\" \"", files)}\"");
+            result.Args.Should().Contain($"--file \"{string.Join("\" \"", files).Replace(System.IO.Path.AltDirectorySeparatorChar, System.IO.Path.DirectorySeparatorChar)}\"");
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace Cake.Codecov.Tests
             var result = fixture.Run();
 
             result.Args.Should()
-                .Be($"--file \"{file}\"");
+                .Be($"--file \"{file.Replace(System.IO.Path.AltDirectorySeparatorChar, System.IO.Path.DirectorySeparatorChar)}\"");
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace Cake.Codecov.Tests
             result.Args.Should()
                 .ContainAll(new[]
                 {
-                    $"--file \"{file}\"",
+                    $"--file \"{file.Replace(System.IO.Path.AltDirectorySeparatorChar, System.IO.Path.DirectorySeparatorChar)}\"",
                     $"--token \"{token}\""
                 });
         }

--- a/Source/Cake.Codecov.Tests/CodecovRunnerTests.cs
+++ b/Source/Cake.Codecov.Tests/CodecovRunnerTests.cs
@@ -311,6 +311,31 @@ namespace Cake.Codecov.Tests
         }
 
         [Fact]
+        public void Should_Normalize_File_Paths()
+        {
+            var fixture = new CodecovRunnerFixture
+            {
+                Settings =
+                {
+                    Files = new[]
+                    {
+                        string.Format(".{0}path{0}to{0}file.txt", System.IO.Path.AltDirectorySeparatorChar)
+                    }
+                }
+            };
+
+            var expectedPaths = System.IO.Path.Combine(
+                ".",
+                "path",
+                "to",
+                "file.txt");
+
+            var result = fixture.Run();
+
+            result.Args.Should().Be($"--file \"{expectedPaths}\"");
+        }
+
+        [Fact]
         public void Should_Set_Flags()
         {
             // Given

--- a/Source/Cake.Codecov/CodecovRunner.cs
+++ b/Source/Cake.Codecov/CodecovRunner.cs
@@ -92,6 +92,11 @@ namespace Cake.Codecov
 
         private static void AddValue(ProcessArgumentBuilder builder, string key, string value, bool onlyAppendValue = false)
         {
+            if (key.Equals("--file", StringComparison.OrdinalIgnoreCase))
+            {
+                value = NormalizePath(value);
+            }
+
             if (key.StartsWith("!", StringComparison.OrdinalIgnoreCase))
             {
                 if (onlyAppendValue)
@@ -114,6 +119,25 @@ namespace Cake.Codecov
                     builder.AppendSwitchQuoted(key, " ", value);
                 }
             }
+        }
+
+        private static string NormalizePath(ReadOnlySpan<char> value)
+        {
+            Span<char> normalizedPath = stackalloc char[value.Length];
+
+            for (var i = 0; i < value.Length; i++)
+            {
+                if (value[i] == System.IO.Path.AltDirectorySeparatorChar)
+                {
+                    normalizedPath[i] = System.IO.Path.DirectorySeparatorChar;
+                }
+                else
+                {
+                    normalizedPath[i] = value[i];
+                }
+            }
+
+            return normalizedPath.ToString();
         }
 
         private static ProcessArgumentBuilder GetArguments(CodecovSettings settings)


### PR DESCRIPTION
- Normalize file paths by replacing alternate directory separators with the platform-specific separator when adding --file arguments.
- Ensure consistent and correct path formatting across different operating systems.
- Update tests to expect normalized paths.
- Add a new test verifying that file paths are properly normalized in the generated arguments.

fixes #332 