### PR TITLE
(#333)  Format --file argument with comma-separated values

### DIFF
--- a/Source/Cake.Codecov.Tests/CodecovAliasesTests.cs
+++ b/Source/Cake.Codecov.Tests/CodecovAliasesTests.cs
@@ -52,7 +52,7 @@ namespace Cake.Codecov.Tests
 
             var result = fixture.Run();
 
-            result.Args.Should().Contain($"--file \"{string.Join("\" \"", files).Replace(System.IO.Path.AltDirectorySeparatorChar, System.IO.Path.DirectorySeparatorChar)}\"");
+            result.Args.Should().Contain($"--file \"{string.Join("\",\"", files).Replace(System.IO.Path.AltDirectorySeparatorChar, System.IO.Path.DirectorySeparatorChar)}\"");
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Cake.Codecov.Tests
             result.Args.Should()
                 .ContainAll(new[]
                 {
-                    $"--file \"{string.Join("\" \"", files)}\"",
+                    $"--file \"{string.Join("\",\"", files)}\"",
                     $"--token \"{token}\""
                 });
         }

--- a/Source/Cake.Codecov.Tests/CodecovRunnerTests.cs
+++ b/Source/Cake.Codecov.Tests/CodecovRunnerTests.cs
@@ -307,7 +307,7 @@ namespace Cake.Codecov.Tests
             var result = fixture.Run();
 
             // Then
-            result.Args.Should().Be(@"--file ""file1.xml"" ""file2.xml""");
+            result.Args.Should().Be(@"--file ""file1.xml"",""file2.xml""");
         }
 
         [Fact]

--- a/Source/Cake.Codecov/CodecovRunner.cs
+++ b/Source/Cake.Codecov/CodecovRunner.cs
@@ -66,6 +66,23 @@ namespace Cake.Codecov
 
         private static void AddValue(ProcessArgumentBuilder builder, string key, IEnumerable<string> value)
         {
+            if (key.Equals("--file", StringComparison.OrdinalIgnoreCase))
+            {
+                value = value.Select(v => NormalizePath(v));
+
+                var combinedValues = '"' + string.Join(
+                    "\",\"",
+                    value) + '"';
+
+                // In this case we know it isn't a secret value,
+                // so no need to do any additional handling.
+                builder.AppendSwitch(
+                    key,
+                    " ",
+                    combinedValues);
+                return;
+            }
+
             var allValues = value.ToList();
             AddValue(builder, key, allValues.FirstOrDefault());
             foreach (var subValue in allValues.Skip(1))


### PR DESCRIPTION
- Update argument formatting for the --file option to use a comma-separated list enclosed in quotes instead of space-separated values.
- Modify tests to expect the new format.
- Improve compatibility with the Codecov CLI argument parsing by ensuring the Codecov runner passes file paths correctly.

fixes #333