### PR TITLE
ci(workflows): update .NET versions to 6.x and 7.x only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,11 +48,9 @@ jobs:
       - name: install .NET versions
         uses: actions/setup-dotnet@v4.0.0
         with:
-          # codecov in cake.recipe needs 2.1!
-          # version used for GitReleaseManager needs .NET Core 3.0
+          # GitVersion needs 6.x
+          # GitReleaseManager needs 7.x
           dotnet-version: |
-            3.1.x
-            5.0.x
             6.0.x
             7.0.x
       - name: Build Addin

--- a/.github/workflows/pre-release-notes.yml
+++ b/.github/workflows/pre-release-notes.yml
@@ -22,12 +22,9 @@ jobs:
       - name: install .NET versions
         uses: actions/setup-dotnet@v4.0.0
         with:
-          # codecov in cake.recipe needs 2.1!
-          # version used for GitReleaseManager needs .NET Core 3.0
           dotnet-version: |
-            3.1.x
-            5.0.x
             6.0.x
+            7.0.x
       - name: Set up git version
         if: ${{ !contains(github.ref, '/hotfix/') && !contains(github.ref, '/release/') }}
         uses: gittools/actions/gitversion/setup@v4.0.0

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -22,12 +22,9 @@ jobs:
       - name: install .NET versions
         uses: actions/setup-dotnet@v4.0.0
         with:
-          # codecov in cake.recipe needs 2.1!
-          # version used for GitReleaseManager needs .NET Core 3.0
           dotnet-version: |
-            3.1.x
-            5.0.x
             6.0.x
+            7.0.x
       - name: Set up git version
         if: ${{ !contains(github.ref, '/hotfix/') && !contains(github.ref, '/release/') }}
         uses: gittools/actions/gitversion/setup@v4.0.0


### PR DESCRIPTION
- Removed .NET Core 3.1 from the CI build matrix to test for potential issues.
- Removed .NET 5.0 from the CI build matrix to test for potential issues.