### PR TITLE
(docs) Add detailed pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,48 @@
+## Bug description
+
+## Root cause
+
+```text
+Root cause analysis:
+- 
+```
+
+## Fix summary
+
+```text
+Fix details:
+- 
+```
+
+## Regression risk
+
+```text
+Risk assessment:
+- 
+```
+
+## Reproduction steps
+
+1. 
+2. 
+3. 
+
+Expected:
+- 
+
+Actual:
+- 
+
+## Testing
+
+- [ ] Added regression tests
+- [ ] Verified scenario behavior
+- [ ] `./build.ps1`/ `./build.sh` passes locally
+
+## Related issues / links
+
+## Checklist
+
+- [ ] Fix is minimal and targeted
+- [ ] No unintended API changes
+- [ ] Documentation updated if relevant

--- a/.github/PULL_REQUEST_TEMPLATE/build_refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/build_refactor.md
@@ -1,0 +1,40 @@
+## Type of change
+
+- [ ] Build / CI configuration only
+- [ ] Code refactoring (no behavior change intended)
+- [ ] Dependency / tooling update
+
+## Summary
+
+## Details
+
+### Scope
+
+```text
+Areas affected:
+- 
+```
+
+### Behavior
+
+- [ ] No behavior changes intended
+
+## Testing
+
+- [ ] `./build.ps1`/ `./build.sh` passes locally
+- [ ] Build scripts verified
+
+## Risk & rollback
+
+```text
+Potential risks:
+- 
+Rollback:
+- 
+```
+
+## Checklist
+
+- [ ] Follows repository coding style
+- [ ] No public API changes
+- [ ] Build and Codecov still function correctly

--- a/.github/PULL_REQUEST_TEMPLATE/docs_only.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs_only.md
@@ -1,0 +1,26 @@
+## Type of documentation change
+
+- [ ] README updates
+- [ ] XML documentation comments
+- [ ] Usage examples
+- [ ] Changelog updates
+- [ ] Other:
+
+## Summary
+
+## Motivation
+
+## Files / sections updated
+
+```text
+- 
+```
+
+## Screenshots / examples (if applicable)
+
+## Checklist
+
+- [ ] No production code changes
+- [ ] Documentation is accurate
+- [ ] Formatting and spelling checked
+- [ ] Links verified

--- a/.github/PULL_REQUEST_TEMPLATE/feature_improvement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_improvement.md
@@ -1,0 +1,61 @@
+## Type of change
+
+- [ ] New feature
+- [ ] Enhancement / improvement to existing behavior
+
+## Summary
+
+<!-- What is the new capability or improvement? -->
+
+## Motivation
+
+<!-- Why is this needed? What problem does it solve for Cake.Codecov users? -->
+
+## Design & implementation
+
+### Public API changes
+
+```text
+New / changed aliases or APIs:
+- 
+```
+
+### Behavior details
+
+```text
+User-facing behavior:
+- 
+Internal behavior:
+- 
+```
+
+## Testing
+
+- [ ] New unit tests added
+- [ ] New integration / scenario tests added
+- [ ] Existing tests updated as needed
+- [ ] `./build.ps1`/ `./build.sh` passes locally
+
+## Breaking changes
+
+- [ ] No breaking changes
+- [ ] Yes, breaking changes (details below):
+
+```text
+Breaking change details:
+- Impact on existing build scripts:
+- Migration guidance:
+```
+
+## Documentation
+
+- [ ] README or usage examples updated
+- [ ] Cake website docs issue/PR created (if applicable)
+- [ ] Not required (internal-only change)
+
+## Checklist
+
+- [ ] Follows `.editorconfig` and repository style
+- [ ] Public APIs have XML documentation
+- [ ] Feature flags or settings have sensible defaults
+- [ ] Considered performance and CI impact (build time, Codecov upload, etc.)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## Summary
+
+<!-- What does this PR change and why? High-level overview. -->
+
+## Related issues / links
+
+<!-- e.g. Fixes #123, Relates to cake-contrib/Cake.Codecov#456, etc. -->
+
+## Implementation details
+
+<!-- Briefly describe the approach, important design decisions, and trade-offs. -->
+
+## Testing
+
+<!-- Describe how you tested these changes. -->
+- [ ] `./build.ps1`/ `./build.sh`
+- [ ] Additional tests (please specify):
+
+```text
+Test commands:
+- 
+```
+
+## Breaking changes
+
+<!--
+Does this introduce a breaking change for consumers of Cake.Codecov?
+If yes, explain impact and migration guidance.
+-->
+- [ ] No breaking changes
+- [ ] Yes, this is a breaking change (details below):
+
+```text
+Breaking change details:
+- Impact:
+- Migration steps:
+```
+
+## Checklist
+
+- [ ] Follows repository coding style and `.editorconfig`
+- [ ] New / changed behavior is covered by unit and/or integration tests
+- [ ] Public APIs have XML documentation comments
+- [ ] Documentation has been updated if needed (README, Cake docs, etc.)
+- [ ] I have considered the impact on build, CI, and release (GitReleaseManager, Codecov config, etc.)


### PR DESCRIPTION
## Type of documentation change

- [ ] README updates
- [ ] XML documentation comments
- [ ] Usage examples
- [ ] Changelog updates
- [x] Other: Templates

## Summary

- Added five standardized PR templates to guide contributions and ensure consistent metadata:
  - general pull_request_template.md with sections for summary, implementation details, testing, breaking changes, and checklist
  - bugfix template capturing root cause, reproduction steps, and targeted testing
  - docs_only template for documentation-focused changes
  - feature_improvement template detailing API changes and testing checklist
  - build_refactor template covering CI and build-related details

## Motivation

- Improve contributor guidance, make reviews more consistent, and simplify CI validation by requiring structured PR information.

## Files / sections updated

```text
- .github/pull_request_template.md (general)
- .github/pull_request_template_bugfix.md
- .github/pull_request_template_docs_only.md
- .github/pull_request_template_feature_improvement.md
- .github/pull_request_template_build_refactor.md
```

## Screenshots / examples (if applicable)

## Checklist

- [x] No production code changes
- [x] Documentation is accurate
- [ ] Formatting and spelling checked (_No Linting available currently_)
- [ ] Links verified